### PR TITLE
ALS-3042, ALS-2761: New search results use datatables

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -96,7 +96,7 @@ define(["handlebars", "studyAccess/studyAccess", "text!common/mainLayout.hbs", "
                     filterListView.render();
 
                     let toolSuiteView = new ToolSuiteView({
-                        isOpenAccess: false,
+
                         el: $('#tool-suite-panel')
                     });
 

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
@@ -574,6 +574,10 @@ input[type='checkbox'].categorical-filter-input {
     min-width: 20%;
 }
 
+.pointer {
+    cursor: pointer;
+}
+
 /************************* STARTS Search X/reset button ******************************/
 
 input[type="search"]::-webkit-search-cancel-button {

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
@@ -727,3 +727,12 @@ remove when above bug is fixed */
 #search-results-datatable tr {
     cursor: pointer;
 }
+
+#search-results-datatable th {
+    cursor: auto;
+    pointer-events: none;
+}
+
+.focused-search-result {
+    border: 4px solid #a73039!important;
+}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
@@ -578,6 +578,10 @@ input[type='checkbox'].categorical-filter-input {
     cursor: pointer;
 }
 
+.no-mouse-events {
+    pointer-events: none;
+}
+
 /************************* STARTS Search X/reset button ******************************/
 
 input[type="search"]::-webkit-search-cancel-button {
@@ -680,6 +684,8 @@ remove when above bug is fixed */
 
 #show-all-tags-btn, #show-fewer-tags-btn {
     cursor: pointer;
+    pointer-events: auto;
+    padding: 0.5em;
 }
 
 #patient-count-box {
@@ -716,4 +722,8 @@ remove when above bug is fixed */
 .var-info {
     list-style-type: none;
     padding: 0;
+}
+
+#search-results-datatable tr {
+    cursor: pointer;
 }

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
@@ -4,7 +4,19 @@
     <h4>Search Results:</h4>
     <span>{{variableCount}} variables match your search</span>
   </div>
-  {{#each results}}
+  <table id="search-results-datatable" class="table table-striped row-border hover">
+    <thead>
+        <tr>
+            <th>Study</th>
+            <th>Dataset ID</th>
+            <th>Variable ID</th>
+            <th>Variable Name</th>
+            <th>Variable Description</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+  </table>
+  {{!-- {{#each results}}
     <div id='search-result-{{this.variable_id}}' class='panel-body search-result' data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-result-index="{{this.result_index}}" data-study-id="{{study_id}}"
     aria-label="Variable {{this.name}}, {{this.variable_id}} described as {{this.description}} from study {{this.abbreviation}}, {{this.study_id}}. Press enter to get more information about this variable or to create a cohort filter using this variable.">
       <span class='col' data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-study-id="{{study_id}}" data-result-index="{{this.result_index}}">{{this.abbreviation}}<br>{{this.variable_id}} </span>
@@ -16,7 +28,7 @@
         {{/if}}
       </span>
     </div>
-  {{/each}}
+  {{/each}} --}}
     <style>
       .paginate_button {
         box-sizing: border-box;
@@ -44,10 +56,10 @@
         background: linear-gradient(to bottom, white 0%, #dcdcdc 100%);
       }
     </style>
-    <div class='search-result-pages row'>
+    {{!-- <div class='search-result-pages row'>
       {{#each pages}}
       <span id='page-link-{{pageNumber}}' class='page-link' data-page='{{pageNumber}}'><a class="paginate_button{{#if isActive}} current{{/if}}" id='page-{{pageNumber}}'>{{pageNumber}}</a></span>
       {{/each}}
-    </div>
+    </div> --}}
 </div>
 {{/if}}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
@@ -1,10 +1,19 @@
+<style>
+  table.dataTable {
+        width: 100%;
+        margin: 0 auto;
+        clear: both;
+        border-collapse: collapse;
+        border-spacing: 0;
+    }
+</style>
 {{#if results}}
 <div class="panel">
   <div class="space-out panel-heading">
     <h4>Search Results:</h4>
     <span>{{variableCount}} variables match your search</span>
   </div>
-  <table id="search-results-datatable" class="table table-striped row-border hover">
+  <table id="search-results-datatable" tabindex="0" class="table table-striped row-border hover" role="region" aria-label="You are in the results region. Use the up and down arrows to move between search results. Use the left and right arrows to move between pages of search results. You are currently on page {{pageNum}} out of {{numPages}} pages of search results with up to 10 results per page.">
     <thead>
         <tr>
             <th>Study</th>
@@ -16,50 +25,5 @@
         </tr>
     </thead>
   </table>
-  {{!-- {{#each results}}
-    <div id='search-result-{{this.variable_id}}' class='panel-body search-result' data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-result-index="{{this.result_index}}" data-study-id="{{study_id}}"
-    aria-label="Variable {{this.name}}, {{this.variable_id}} described as {{this.description}} from study {{this.abbreviation}}, {{this.study_id}}. Press enter to get more information about this variable or to create a cohort filter using this variable.">
-      <span class='col' data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-study-id="{{study_id}}" data-result-index="{{this.result_index}}">{{this.abbreviation}}<br>{{this.variable_id}} </span>
-      <span class='col' data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-study-id="{{study_id}}" data-result-index="{{this.result_index}}">[{{this.name}}] {{this.description}} </span>
-      <span class='search-result-icons col'>
-        <i data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-result-index="{{this.result_index}}" title="Click to configure a filter using this variable." class="fa fa-filter search-result-action-btn"></i>
-        {{#if ../isAuthorized}}
-        <i data-data-table-id="{{this.table_id}}" data-variable-id="{{this.variable_id}}" data-result-index="{{this.result_index}}" title="Click to add this variable to your data retrieval." class="glyphicon glyphicon-log-out export-icon search-result-action-btn"></i>
-        {{/if}}
-      </span>
-    </div>
-  {{/each}} --}}
-    <style>
-      .paginate_button {
-        box-sizing: border-box;
-        display: inline-block;
-        min-width: 1.5em;
-        padding: .5em 1em;
-        margin-left: 2px;
-        text-align: center;
-        cursor: pointer;
-        *cursor: hand;
-        color: #333 !important;
-        border: 1px solid transparent;
-        border-radius: 2px;
-      }
-  
-      .paginate_button.current {
-        color: #333 !important;
-        border: 1px solid #979797;
-        background-color: white;
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #dcdcdc));
-        background: -webkit-linear-gradient(top, white 0%, #dcdcdc 100%);
-        background: -moz-linear-gradient(top, white 0%, #dcdcdc 100%);
-        background: -ms-linear-gradient(top, white 0%, #dcdcdc 100%);
-        background: -o-linear-gradient(top, white 0%, #dcdcdc 100%);
-        background: linear-gradient(to bottom, white 0%, #dcdcdc 100%);
-      }
-    </style>
-    {{!-- <div class='search-result-pages row'>
-      {{#each pages}}
-      <span id='page-link-{{pageNumber}}' class='page-link' data-page='{{pageNumber}}'><a class="paginate_button{{#if isActive}} current{{/if}}" id='page-{{pageNumber}}'>{{pageNumber}}</a></span>
-      {{/each}}
-    </div> --}}
 </div>
 {{/if}}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-table-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-table-view.js
@@ -3,50 +3,12 @@ define(['backbone', 'handlebars', 'datatables.net', "common/keyboard-nav", "sear
         let searchTable = BB.View.extend({
             initialize: function(opts){
                 this.data = opts;
-                //this.processResults();
                 this.template = HBS.compile(searchResultsListTemplate);
-            },
-            processResults: function(){
-                let processedResults = [];
-                _.each(this.data.results, function(result) {
-                    processedResults.push({
-                        study: result.abbreviation,
-                        dataset: result.dataTableDescription,
-                        variableId: result.variable_id,
-                        variableName: result.name,
-                    });
-                });
-                this.data.processedResults = processedResults;
             },
             render: function(){
                 console.log("rendering searchTable");
                 this.$el.html(this.template(this.data));
-                // $('#search-results-datatable').DataTable({
-                //     data: this.data.processedResults,
-                //     columns: [
-                //         {title:'Study', data:'study'},
-                //         {title:'Dataset',data:'dataset'},
-                //         {title:'Variable ID', data:'variableId'},
-                //         {title:'Variable Name', data:'variableName'},
-                //     ],
-                // });
             }
         });
         return searchTable;
     });
-
-    // columns: [
-    //     {title:'Study'},
-    //     {title:'Dataset'},
-    //     {title: 'Variable ID'},
-    //     {title:'Variable name'},
-    //     {title:'Actions'}
-    //    ],
-    // select: {
-    //     style:    'os',
-    //     selector: 'td:first-child',
-    //     toggleable: false
-    // },
-    // drawCallback: function(){
-    //     console.log("drawCallback");
-    // }

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-table-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-table-view.js
@@ -1,0 +1,52 @@
+define(['backbone', 'handlebars', 'datatables.net', "common/keyboard-nav", "search-interface/filter-model", "search-interface/search-util", "text!search-interface/search-results-list.hbs"],
+	function(BB, HBS, datatables, keyboardNav,  filterModel, searchUtil, searchResultsListTemplate){
+        let searchTable = BB.View.extend({
+            initialize: function(opts){
+                this.data = opts;
+                //this.processResults();
+                this.template = HBS.compile(searchResultsListTemplate);
+            },
+            processResults: function(){
+                let processedResults = [];
+                _.each(this.data.results, function(result) {
+                    processedResults.push({
+                        study: result.abbreviation,
+                        dataset: result.dataTableDescription,
+                        variableId: result.variable_id,
+                        variableName: result.name,
+                    });
+                });
+                this.data.processedResults = processedResults;
+            },
+            render: function(){
+                console.log("rendering searchTable");
+                this.$el.html(this.template(this.data));
+                // $('#search-results-datatable').DataTable({
+                //     data: this.data.processedResults,
+                //     columns: [
+                //         {title:'Study', data:'study'},
+                //         {title:'Dataset',data:'dataset'},
+                //         {title:'Variable ID', data:'variableId'},
+                //         {title:'Variable Name', data:'variableName'},
+                //     ],
+                // });
+            }
+        });
+        return searchTable;
+    });
+
+    // columns: [
+    //     {title:'Study'},
+    //     {title:'Dataset'},
+    //     {title: 'Variable ID'},
+    //     {title:'Variable name'},
+    //     {title:'Actions'}
+    //    ],
+    // select: {
+    //     style:    'os',
+    //     selector: 'td:first-child',
+    //     toggleable: false
+    // },
+    // drawCallback: function(){
+    //     console.log("drawCallback");
+    // }

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-view.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-view.hbs
@@ -13,9 +13,6 @@
 	.search-result:first-of-type {
 		border-top: 1px solid;
 	}
-	.search-result-icons {
-		float:right;
-	}
 	.search-result-icons .glyphicon{
 		font-size:1.3em;
 		cursor:pointer;

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-view.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-view.hbs
@@ -1,9 +1,4 @@
 <style>
-	.focused-search-result {
-    	border-top: 1px solid;
-		border-width:4px !important;
-		border-color:#a73039 !important;
-	}
 	.search-result {
 		border-bottom: 1px solid;
 		padding:3px;
@@ -52,7 +47,7 @@
     display: inline-block;
 	}
 </style>
-<div id='search-results-div' role="region" aria-label="You are in the results region. Use the up and down arrows to move between search results. Use the left and right arrows to move between pages of search results. You are currently on page {{pageNum}} out of {{numPages}} pages of search results with up to 10 results per page." tabindex=0>
+<div id='search-results-div' role="region">
 
 </div>
 <div id='aria-live' aria-live='polite' style="position:absolute;left:-99999;display:hidden;"></div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-view.js
@@ -277,23 +277,14 @@ function(BB, HBS, searchResultsViewTemplate, searchResultsListTemplate,
 						}
 					],
                 });
-// 				abbreviation: "CARDIA"
-// dataTableDescription: "Subject Identifier"
-// description: "REASON(S) FOR HOSPITALIZATION"
-// name: "YTRCARR"
-// result_index: 0
-// study_id: "phs000285"
-// table_id: "pht001867"
-// variable_id: "phv00121188"
-
-				// $('#search-results-div').html(HBS.compile(searchResultsListTemplate)(
-				// 	{
-				// 		"isAuthorized": this.isAuthorized,
-				// 		"results": results,
-				// 		"variableCount": tagFilterModel.get("searchResults").results.numResults,
-				// 		"pages": pages
-				// 	}
-				// ));
+				// abbreviation: "CARDIA"
+				// dataTableDescription: "Subject Identifier"
+				// description: "REASON(S) FOR HOSPITALIZATION"
+				// name: "YTRCARR"
+				// result_index: 0
+				// study_id: "phs000285"
+				// table_id: "pht001867"
+				// variable_id: "phv00121188"
 				$('#search-results-div').attr('aria-label',
 					"You are in the results region on page " +
 					tagFilterModel.get("currentPage") + " out of " + pages.length +

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
@@ -111,8 +111,7 @@ define(["jquery","backbone","handlebars","search-interface/tag-filter-view","sea
 					includedTags: this.requiredTags,
 					excludedTags: searchExcludeTags,
 					returnTags: true,
-					offset: (tagFilterModel.get("currentPage")-1) * tagFilterModel.get("limit"),
-					limit: tagFilterModel.get("limit")
+					limit: 1000000
 				}}),
 				success: function(response){
 					//deferredSearchResults.resolve();

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tag-filter-view.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tag-filter-view.hbs
@@ -7,6 +7,7 @@
 		background: white;
 		border: solid;
 		border-width: 1px;
+		pointer-events: auto;
 	}
 
 	.focused-tag-badge {
@@ -72,6 +73,7 @@
 	}
 	.badge {
 		font-weight: normal;
+		pointer-events: auto;
 	}
 	.badge .bold-tag {
 		font-weight: 700;
@@ -85,7 +87,7 @@
 	}
 </style>
 {{#if hasActiveTags}}
-<div id='active-tags-section-div' role='region' class='panel section' tabindex=0 aria-label='You are in the active tag filters region. 
+<div id='active-tags-section-div' role='region' class='panel section no-mouse-events' tabindex=0 aria-label='You are in the active tag filters region. 
 	Currently {{numActiveTags}} tags are being used to filter search results for your search term "{{searchTerm}}". Currently {{numSearchResults}} search results are displayed in the results region.
 	{{#if hasRequiredTags}} The results are filtered by requiring the following tags: 
 		{{#each requiredTags}}{{ariaAliasIfStudy this.tag}}... {{/each}}.
@@ -132,7 +134,7 @@
 </div>
 {{/if}}
 {{#if hasInactiveStudyTags}}
-<div id='study-tags-section-div' role='region' class='panel section' tabindex=0
+<div id='study-tags-section-div' role='region' class='panel section no-mouse-events' tabindex=0
 	aria-label="You are in the study tag filters region. Use arrows keys to move between study tag filters. Use the plus and minus keys to include or exclude tags.">
 	<div class="space-out panel-heading">
 		<span>Filter Search Results by Study Tags</span>
@@ -154,7 +156,7 @@
 </div>
 {{/if}}
 {{#if this.tagsShown}}
-<div id='tags-section-div' role='region' class='panel section' tabindex=0
+<div id='tags-section-div' role='region' class='panel section no-mouse-events' tabindex=0
 	aria-label="You are in the tag filters region. Use up and down arrows to move between tag filters.">
 	<div class='panel-heading'>
 		Filter Search Results by Variable Tags
@@ -174,9 +176,9 @@
 		{{/each}}
 		<br>
 		{{#if tagsLimited}}
-		<span id="show-all-tags-btn"> <span class="glyphicon glyphicon-chevron-down"></span> View more tags</span>
+		<span id="show-all-tags-btn" tabindex="0"> <span class="glyphicon glyphicon-chevron-down"></span> View more tags</span>
 		{{else}}
-		<span id="show-fewer-tags-btn"> <span class="glyphicon glyphicon-chevron-up"></span> View fewer tags</span>
+		<span id="show-fewer-tags-btn" tabindex="0"> <span class="glyphicon glyphicon-chevron-up"></span> View fewer tags</span>
 		{{/if}}
 	</div>
 </div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tag-filter-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tag-filter-view.js
@@ -11,6 +11,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 		initialize: function(opts){
 			this.isOpenAccess = opts.isOpenAccess;
 			this.model = tagFilterModel;
+			this.clicked = false;
 			this.helpView = new helpView();
 			this.onTagChange = opts.onTagChange;
 			this.model.get('requiredTags').bind('change add remove', this.modelChanged.bind(this));
@@ -31,7 +32,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 		events: {
 			'mouseover .badge': 'showTagControls',
 			'mouseout .badge': 'hideTagControls',
-			'click .badge': 'clickTag',
+			'click .hover-control': 'clickTag',
 			'click #show-all-tags-btn': 'showAllTags',
 			'click #show-fewer-tags-btn': 'showFewerTags',
 			'focus #active-tags-section-div': 'activeTagFocus',
@@ -60,7 +61,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 				this.model.removeRequiredTag(focusedTag.id.split('-')[1]);
 			}
 		},
-		previousTag: function(event){
+		previousTag: function(e){
 			let tags = this.$(this.model.get("focusedSection") + " .section-body .badge");
 			let focusedTag = 1;
 			for(var x = 0;x < tags.length;x++){
@@ -78,7 +79,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 			$('.focused-tag-badge .hover-control').css('visibility','visible');
 			searchUtil.ensureElementIsInView($('.focused-tag-badge')[0]);
 		},
-		nextTag: function(event){
+		nextTag: function(e){
 			let tags = this.$(this.model.get("focusedSection") + " .section-body .badge");
 			let focusedTag = -1;
 			for(var x = 0;x < tags.length;x++){
@@ -113,7 +114,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 		},
 		activeTagFocus: function(){
 			this.model.set('focusedSection', '#active-tags-section-div', {silent:true});
-			this.nextTag();
+			this.focusFirstTag();
 			keyboardNav.setCurrentView("tagFilters");
 		},
 		activeTagBlur: function(){
@@ -124,7 +125,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 		},
 		tagFocus: function(){
 			this.model.set('focusedSection', '#tags-section-div', {silent:true});
-			this.nextTag();
+			this.focusFirstTag();
 			keyboardNav.setCurrentView("tagFilters");
 		},
 		tagBlur: function(){
@@ -135,7 +136,7 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 		},
 		studyTagFocus: function(){
 			this.model.set('focusedSection', '#study-tags-section-div', {silent:true});
-			this.nextTag();
+			this.focusFirstTag();
 			keyboardNav.setCurrentView("tagFilters");
 		},
 		studyTagBlur: function(){
@@ -143,6 +144,11 @@ function(BB, HBS, tagFilterViewTemplate, tagFilterModel, filterModel, keyboardNa
 			$('.focused-tag-badge .hover-control').css('visibility','hidden');
 			this.$("#study-tags-section-div .section-body .focused-tag-badge").removeClass('focused-tag-badge');
 			keyboardNav.setCurrentView(undefined);
+		},
+		focusFirstTag: function(){
+			const tags = this.$(this.model.get("focusedSection") + " .section-body .badge");
+			tags && $(tags[0]).addClass('focused-tag-badge');
+			tags && $('.focused-tag-badge .hover-control').css('visibility','visible');
 		},
 		// queryUpdated: function(model, collection, opts){
 		// 	var studiesInScope = _.filter(filterModel.get('activeFilters').models, (model) => {model.toJSON().searchResult !== undefined})


### PR DESCRIPTION
The Search results should use data tables while following 508 compliance. 
Makes the white space around the +/- buttons not clickable
Makes the white space outside the tags not clickable