### PR TITLE
ALS-3561: adds result panel styling

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/common/mainLayout.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/common/mainLayout.hbs
@@ -12,9 +12,14 @@
 
 <div id="query-builder" class="flex-container space-between">
     <div id="filter-list"></div>
-    <div class="output-size">    
-        <div id="query-results"></div>
-        <div id="tool-suite-panel"></div>
-        <div id="filter-list-panel"></div>
+    <div class="output-size panel results-panel">    
+        <div class="results-panel-header panel-heading">
+            <h3>Results Panel</h3>
+        </div>
+        <div class="panel-body">
+            <div id="query-results"></div>
+            <div id="tool-suite-panel"></div>
+            <div id="filter-list-panel"></div>
+        </div>
     </div>
 </div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/openMainLayout.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/openMainLayout.hbs
@@ -1,8 +1,13 @@
 <div id="query-builder" class="flex-container space-between">
     <div id="filter-list"></div>
-    <div class="output-size">    
-        <div id="query-results"></div>
-        <div id="filter-list-panel"></div>
-        <div id="studies-list-panel"></div>
+    <div class="output-size panel results-panel">  
+         <div class="results-panel-header panel-heading">
+            <h3>Results Panel</h3>
+        </div>
+        <div class="panel-body">
+            <div id="query-results"></div>
+            <div id="filter-list-panel"></div>
+            <div id="studies-list-panel"></div>
+        </div>  
     </div>
 </div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/outputPanel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/outputPanel.hbs
@@ -17,7 +17,7 @@
 <div class="panel">
 <div class="space-out panel-heading">
         <span>Data Summary</span>
-        <i id="open-access-output-help" class="fa fa-info-circle fa-lg btn btn-icon" tabindex="0" title="Open Access Help"></i>
+        <a id="open-access-output-help" class="btn no-padding" title="Open Access Help" tabindex="0" aria-label="Open Access Help">More Details</a>
 </div>
 <div id="patient-count-box" class="panel-body">
 	<div class="center large" id="spinner-total">{{#if spinning}}{{> spinner spinnerClasses}}{{/if}}</div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/studiesPanel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/studiesPanel.hbs
@@ -79,7 +79,7 @@
 <div id="studies-list" class="panel">
     <div class="space-out panel-heading">
         <span>Filtered Results by Study</span>
-        <i id="studies-help" class="fa fa-info-circle fa-lg btn btn-icon" tabindex="0" title="Studies Help"></i>
+        <a id="studies-help" class="btn no-padding" title="Studies Help" aria-label="Studies Help" tabindex="0" >More Details</a>
     </div>
     <div class="panel-body" tabindex="0">
         {{#each studies}}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
@@ -789,3 +789,18 @@ remove when above bug is fixed */
 .disabled-icon {
     color: #adadad;
 }
+
+.results-panel {
+    background-color: #e3eefd;
+    height: fit-content;
+}
+
+.panel .results-panel-header {
+    color: var(--catalyst-dark-grey);
+    border-bottom: none;
+    padding: 2px 15px;
+}
+
+.panel .search-resutls-panel-heading {
+    padding: 5px;
+}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
@@ -802,5 +802,5 @@ remove when above bug is fixed */
 }
 
 .panel .search-resutls-panel-heading {
-    padding: 5px;
+    padding: 5px 15px;
 }

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/query-results-view.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/query-results-view.hbs
@@ -32,7 +32,7 @@
 <div class="panel" id="patient-count-box">
     <div class="space-out panel-heading">
         <span>Data Summary</span>
-        <i id="data-summary-help" class="fa fa-info-circle fa-lg btn btn-icon" tabindex="0" title="Data Summary Help"></i>
+        <a id="data-summary-help" class="btn no-padding" title="Data Summary Help" aria-label="Data Summary Help" tabindex="0" >More Details</a>
     </div>
     <div class="data-summary-body panel-body" >
 	       <span class="center large" id="spinner-total">{{#if spinning}}{{> spinner spinnerClasses}}{{/if}}</span>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
@@ -9,7 +9,7 @@
 </style>
 {{#if results}}
 <div class="panel">
-  <div class="space-out panel-heading">
+  <div class="space-out search-resutls-panel-heading panel-heading">
     <h4>Search Results:</h4>
     <div class="results-container">{{variableCount}} variables match your search <i id="no-results-help" class="fa fa-question-circle fa-lg btn btn-icon m-0" tabindex="0" title="Why might I see unexpected search results?" aria-label="Why might I see unexpected search results?"></i></div>
   </div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-results-list.hbs
@@ -9,7 +9,7 @@
 </style>
 {{#if results}}
 <div class="panel">
-  <div class="space-out search-resutls-panel-heading panel-heading">
+  <div class="search-resutls-panel-heading space-out panel-heading">
     <h4>Search Results:</h4>
     <div class="results-container">{{variableCount}} variables match your search <i id="no-results-help" class="fa fa-question-circle fa-lg btn btn-icon m-0" tabindex="0" title="Why might I see unexpected search results?" aria-label="Why might I see unexpected search results?"></i></div>
   </div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/selection-panel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/selection-panel.hbs
@@ -3,7 +3,7 @@
     <div class="panel-heading space-out panel-extra-large">
         <h4 class="panel-title">{{searchContext}}</h4>
         {{#if description}}
-        <i class="fa fa-info-circle fa-lg tabable" aria-hidden="true" data-toggle="tooltip" data-placement="left" title="{{description}}"></i>
+        <i class="fa fa-question-circle fa-lg tabable" aria-hidden="true" data-toggle="tooltip" data-placement="left" title="{{description}}"></i>
         {{/if}}
     </div>
     <div class="panel-body selection-box tabable" aria-label="You are on a list box. Use the arrow keys to navigate and space or enter to select" role="listbox">

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/selection-search-panel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/selection-search-panel.hbs
@@ -9,7 +9,7 @@
         <div class="panel-heading search-heading space-out">
             <h4 class="panel-title">{{searchContext}}</h4>
             {{#if description}}
-            <i class="fa fa-info-circle fa-lg tabable" aria-hidden="true" data-toggle="tooltip" data-trigger="click hover focus" data-placement="left" title="{{description}}"></i>
+            <i class="fa fa-question-circle fa-lg tabable" aria-hidden="true" data-toggle="tooltip" data-trigger="click hover focus" data-placement="left" title="{{description}}"></i>
             {{else}}
             <button id="{{searchId}}-selection-select-all" class="btn btn-default tabable">Select All</button>
             {{/if}}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tool-suite-view.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tool-suite-view.hbs
@@ -1,7 +1,7 @@
 <div id="tool-suite" class="panel">
     <div class="space-out panel-heading">
         <span>Tool Suite</span>
-        <i id="tool-suite-help" class="fa fa-info-circle fa-lg btn btn-icon" tabindex="0" title="Tool Suite Help"></i>
+        <a id="tool-suite-help" class="btn no-padding" title="Tool suite help" tabindex="0" aria-label="Tool suite help">More Details</a>
     </div>
     <div class="tools panel-body">
         <button id="package-data" class="btn btn-default big-btn tool" disabled>


### PR DESCRIPTION
ALS-3561 AC

- On the search page, the results panel will be highlighted by being outlined in a box. We can make it be a panel of panels with the title “Results Panel”
- 
- “Results Panel” text should be shown above the Data Summary box
- 
- This should be implemented in both the Open and Authorized Access pages.