### PR TITLE
ALS-3698: Disable tool suite view when 0 participants. 

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tool-suite-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/tool-suite-view.js
@@ -4,7 +4,7 @@ function($, BB, HBS, template, filterModel, modal, helpView, VisualizationModalV
         initialize: function(opts){
             this.template = HBS.compile(template);
             this.helpView = new helpView();
-            this.listenTo(filterModel.get('activeFilters'), 'change reset add remove', this.render);
+            this.listenTo(filterModel, 'change reset add remove', this.render);
         },
         events: {
             'click #package-data' : 'openPackageData',


### PR DESCRIPTION
This also fixes some other related issues around that panel incorrectly being enabled/disabled. The problem was that `totalPatients` in `filter-model` was changing after the `activeFilters` changed, and `tool-suite-view` was only listening on `activeFilters`.