### PR TITLE
ALS-3771: Require users to select a gene on the genomic filter modal

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/styles.css
@@ -649,6 +649,21 @@ input[type='checkbox'].categorical-filter-input {
     pointer-events: none;
 }
 
+.selection-required {
+    color: red;
+    font-style: italic;
+    font-size: 90%;
+    padding-left: 5px;
+}
+
+#apply-genomic-filters-tooltip {
+    padding: 10px;
+}
+
+#cancel-genomic-filters {
+    margin: 10px 0;
+}
+
 /************************* STARTS Search X/reset button ******************************/
 
 input[type="search"]::-webkit-search-cancel-button {

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/genomic-filter-view.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/genomic-filter-view.hbs
@@ -32,7 +32,9 @@
         </div>
         <div class="push-left-and-down">
             <button id="cancel-genomic-filters" class="btn-small btn btn-default tabable">Cancel</button>
-            <button id="apply-genomic-filters" class="btn-small btn btn-primary tabable">Apply genomic filter</button>
+            <span id="apply-genomic-filters-tooltip" class="d-inline-block" tabindex="0" data-toggle="tooltip" title="Please select at least one Gene with Variant.">
+                <button id="apply-genomic-filters" class="btn-small btn btn-primary tabable">Apply genomic filter</button>
+            </span>
         </div>
     </section>
 </div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/genomic-filter-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/genomic-filter-view.js
@@ -79,7 +79,8 @@ define(['jquery', 'backbone','handlebars',
                     resultContext: 'Selected genes',
                     placeholderText: 'The list of genes below is a sub-set, try typing other gene names (Ex. CHD8)',
                     description: this.data.geneDesc,
-                    sample: true
+                    sample: true,
+                    isRequired: true
                 }
                 this.dataForConsequenceSearch = {
                     heading: 'Variant consequence calculated',
@@ -195,15 +196,12 @@ define(['jquery', 'backbone','handlebars',
                 }
             },
             updateDisabledButton: function(){
-                if (this.data.categoryVariantInfoFilters && ((this.data.categoryVariantInfoFilters.Gene_with_variant && this.data.categoryVariantInfoFilters.Gene_with_variant.length) ||
-                    (this.data.categoryVariantInfoFilters.Variant_consequence_calculated && this.data.categoryVariantInfoFilters.Variant_consequence_calculated.length) ||
-                    (this.data.categoryVariantInfoFilters.Variant_severity && this.data.categoryVariantInfoFilters.Variant_severity.length) ||
-                    (this.data.categoryVariantInfoFilters.Variant_class && this.data.categoryVariantInfoFilters.Variant_class.length) ||
-                    (this.data.categoryVariantInfoFilters.Variant_frequency_as_text && this.data.categoryVariantInfoFilters.Variant_frequency_as_text.length)
-                )) {
+                if (this.data.categoryVariantInfoFilters && (this.data.categoryVariantInfoFilters.Gene_with_variant && this.data.categoryVariantInfoFilters.Gene_with_variant.length)) {
                     this.$el.find('#apply-genomic-filters').prop('disabled', false);
+                    this.$el.find('#apply-genomic-filters-tooltip').tooltip('disable');
                 } else {
                     this.$el.find('#apply-genomic-filters').prop('disabled', true);
+                    this.$el.find('#apply-genomic-filters-tooltip').tooltip('enable');
                 }
             },
             updateGenomicFilter: function(){

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/selection-search-panel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/selection-search-panel.hbs
@@ -3,7 +3,12 @@
         outline: 4px solid red!important;
     }
 </style>
-<h3 class="selection-heading">{{heading}}</h3>
+<h3 class="selection-heading">
+    {{heading}}
+    {{#if isRequired}}
+        <span class="selection-required">Required</span>
+    {{/if}}
+</h3>
 <div id="{{searchId}}-container" class="selection-container space-even" aria-label="{{description}}" >
     <div class="panel panel-default no-padding half-width">
         <div class="panel-heading search-heading space-out">


### PR DESCRIPTION
* The hacky paddings are due to not being able to put a tooltip directly on a disabled button, and the button itself not propagating mouse events to the parent span.