### PR TITLE
New notebook to validate the new version of a study

### DIFF
--- a/access-dashboard-metadata/confirm_new_version_subject_ids.ipynb
+++ b/access-dashboard-metadata/confirm_new_version_subject_ids.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1760cbb9",
+   "metadata": {},
+   "source": [
+    "When a new version of an existing study is planned to be ingested, ensure the subject ids from the old version match those of the new version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42d44a9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(tidyverse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a3cf18b",
+   "metadata": {},
+   "source": [
+    "load the subject.multi files of both old and new versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "214486a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Replace with file paths to desired subject.multi files\n",
+    "old_raw <- read.table(\"/home/ec2-user/SageMaker/studies/ALL-avillach-73-bdcatalyst-etl/fhs/rawData/phs000007.v31.pht000182.v14.p12.Framingham_Subject.MULTI.txt\", sep=\"\\t\", header=TRUE)\n",
+    "\n",
+    "\n",
+    "new_raw <- read.table(\"/home/ec2-user/SageMaker/studies/ALL-avillach-73-bdcatalyst-etl/fhs/rawData/phs000007.v31.pht000182.v14.p12.Framingham_Subject.MULTI.txt\", sep=\"\\t\", header=TRUE)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7aada66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(old_raw[1:5,])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d34a2b2f",
+   "metadata": {},
+   "source": [
+    "Define which columns are Subject ID and Consents for this study"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "37da60a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "old_renamed <- old_raw %>% rename(\n",
+    "    subject_id = shareid,\n",
+    "    consent = consent_1218\n",
+    ")\n",
+    "\n",
+    "new_renamed <- new_raw %>% rename(\n",
+    "    subject_id = shareid,\n",
+    "    consent = consent_1218\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c55366a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(old_renamed[1:5,])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7db4810a",
+   "metadata": {},
+   "source": [
+    "Check if all IDs in old version are found in new version, ignoring subject ids from Consent 0\n",
+    "\n",
+    "Desired result: FALSE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "aef54fc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "old_renamed <- subset(old_renamed, consent!=0)\n",
+    "old_ids <- old_renamed$subject_id\n",
+    "old_ids <- as.numeric(sort(old_ids))\n",
+    "\n",
+    "new_renamed <- subset(new_renamed, consent!=0)\n",
+    "new_ids <- new_renamed$subject_id\n",
+    "new_ids <- as.numeric(sort(new_ids))\n",
+    "\n",
+    "FALSE %in% (old_ids %in% new_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4449e6f4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "4.2.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
If a new version of a study uses the same subject IDs as the previous version, use this notebook to ensure the IDs match