### PR TITLE
Update search-view genomic filter btn

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
@@ -179,6 +179,7 @@ define(["jquery","backbone","handlebars","search-interface/tag-filter-view","sea
 			$('#search-results').hide();
 			e && $('#tag-filters').hide();
 			$('#search-button').attr('disabled', 'disabled');
+			$('#genomic-filter-btn').attr('disabled', 'disabled');
 
 			let deferredSearchResults = $.ajax({
 				url: window.location.origin + "/picsure/search/36363664-6231-6134-2D38-6538652D3131",
@@ -197,12 +198,14 @@ define(["jquery","backbone","handlebars","search-interface/tag-filter-view","sea
 					$('#tag-filters').show();
 					$('#search-results').show();
 					$('#search-button').removeAttr('disabled');
+					$('#genomic-filter-btn').removeAttr('disabled');
 					$('#spinner-holder').removeClass('big-grow');
 				}.bind(this),
 				error: function(response){
 					//deferredSearchResults.resolve();
 					$("#spinner-holder").html("");
 					$('#search-button').removeAttr('disabled');
+					$('#genomic-filter-btn').removeAttr('disabled');
 					const helpTemplate = HBS.compile(helpViewTemplate);
 					this.$el.html(helpTemplate());
 					console.log(response);


### PR DESCRIPTION
When a user is using the authorized search functionality they can no longer click on the "genomic filter" button while a search is currently in progress.