### PR TITLE
Als 4319 api tab should open a new page

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanel.hbs
@@ -1,0 +1,179 @@
+<style>
+    #intro-section {
+        margin: 0 auto;
+        min-width: 800px;
+        width: fit-content;
+    }
+
+    #get-started-section {
+        margin: 30px 15px 0 15px;
+        padding: 8px 0;
+        min-width: 1200px;
+    }
+
+    .title {
+        font-size: 28px;
+        margin: 0;
+    }
+
+    .sub-title {
+        font-size: 16px;
+        margin: 0;
+    }
+
+    #getting-start-examples > a,
+    #getting-start-examples > button {
+        margin: 5px;
+    }
+
+    #about-section {
+        margin: 30px 15px 0 15px;
+        padding: 8px 0;
+        min-width: 1200px;
+    }
+
+</style>
+<div class="panel panel-outline" id="intro-section">
+    <div class="panel-heading no-border center-panel">
+        <div class="access-title">
+            <h3>PIC-SURE Application Programming Interface (API)</h3>
+        </div>
+    </div>
+    <div class="panel-body" style="display: flex; margin: 0 auto 10px auto">
+        <ul class="plain-list">
+            <li>
+                <i class="fa-solid fa-laptop-code" aria-hidden="true"></i>
+                <span>Search and query the studies in PIC-SURE using code, available in python or R</span>
+            </li>
+            <li>
+                <i class="fa-solid fa-graduation-cap" aria-hidden="true"></i>
+                <span>Tutorials and example code can be accessed via Jupyter notebooks or RStudio</span>
+            </li>
+            <li>
+                <i class="fa-solid fa-scale-balanced" aria-hidden="true"></i>
+                <span>PIC-SURE API is open source and licensed under Apache License 2.0</span>
+            </li>
+        </ul>
+    </div>
+</div>
+<div class="panel panel-outline" id="get-started-section">
+    <div class="panel-heading no-border">
+        <h2 class="title">Getting Started</h2>
+        <div class="sub-title">
+            <p>To use the PIC-SURE API, copy your personalized access token below.</p>
+            <p>Paste the token into a text file in your working directory and save as "token.txt".</p>
+        </div>
+    </div>
+    <div class="panel-body">
+        <div id="user-profile" style="margin: 0 10%; width: 80%">
+
+        </div>
+        <h2 class="title">PIC-SURE API Examples</h2>
+        <div class="sub-title">
+            Access example code on an NHLBI BioData Catalyst® (BDC) analysis platform or on the public GitHub
+            repository.
+        </div>
+        <div style="margin: 0 auto; width: max-content;" id="getting-start-examples">
+            <a class="btn btn-primary btn-lg"
+               href="https://github.com/hms-dbmi/Access-to-Data-using-PIC-SURE-API/tree/master/NHLBI_BioData_Catalyst"
+               aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                <span>Public GitHub Repository</span>
+            </a>
+            <a class="btn btn-primary btn-lg"
+               href="https://accounts.sb.biodatacatalyst.nhlbi.nih.gov/auth/login"
+               aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                BDC Powered by Seven Bridges
+            </a>
+            <button class="btn btn-primary btn-lg" id="bdc-powered-by-terra"
+                    aria-label="Clicking this button will open a modal.">
+                BDC Powered by Terra
+                <i class="fa-solid fa-arrow-up-right-from-square"></i>
+            </button>
+        </div>
+    </div>
+</div>
+<div class="panel panel-outline" id="about-section">
+    <div class="panel-heading no-border">
+        <h2 class="title">About the PIC-SURE API</h2>
+        <div class="sub-title">
+            The PIC-SURE API allows users to search and query BDC studies and export participant-level data using code.
+            This open source API is currently available in python or R. See below for links to more documentation.
+        </div>
+    </div>
+    <div class="panel-body">
+        <h3>PIC-SURE API</h3>
+        <ul>
+            <li>
+                <a href="https://tinyurl.com/BDC-PIC-SURE-User-Guide"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    BDC-PIC-SURE User Guide
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/hms-dbmi/Access-to-Data-using-PIC-SURE-API/tree/master/NHLBI_BioData_Catalyst"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    Access to Data using PIC-SURE GitHub repository
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    PIC-SURE API GitHub repository
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+        </ul>
+        <h3>Python Clients & Adapters on GitHub</h3>
+        <ul>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure-python-client"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    PIC-SURE Python Client
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure-python-adapter-hpds"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    PIC-SURE HPDS Python Client
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    PIC-SURE HPDS Python Adapter for BDC
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+        </ul>
+        <h3>R Clients & Adapters on GitHub</h3>
+        <ul>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure-r-adapter-hpds"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    R Clients & Adapters on GitHub
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure-r-adapter-hpds/blob/master/hpds.pdf"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    PIC-SURE HPDS R Client documentation
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/hms-dbmi/pic-sure-biodatacatalyst-r-adapter-hpds"
+                   aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                    PIC-SURE HPDS R Adapter for BDC
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanelView.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanelView.js
@@ -1,0 +1,34 @@
+define(["jquery", "handlebars", "backbone", "text!api-interface/apiPanel.hbs", "header/userProfile"
+        , "picSure/userFunctions", "api-interface/bdcTerraLinkView", "common/modal"],
+    function ($, HBS, BB, apiPanelTemplate, UserProfile, userFunctions, BdcTerraView, modal) {
+
+        return BB.View.extend({
+            initialize: function (opts) {
+                this.template = HBS.compile(apiPanelTemplate);
+            },
+            events: {
+                'click #bdc-powered-by-terra': "_openBDCTerraModal",
+            },
+            _openBDCTerraModal: function () {
+                const bdcTerraView = new BdcTerraView();
+                modal.displayModal(
+                    bdcTerraView,
+                    "BDC Powered by Terra",
+                    () => {
+                    },
+                    {handleTabs: true, width: "600px"}
+                );
+            },
+            render: function () {
+                userFunctions.meWithToken(this, (user) => {
+                    let userProfile = new UserProfile(user);
+                    $('#user-profile').html(userProfile.$el);
+                    userProfile.render();
+                });
+
+                this.$el.html(this.template);
+                return this;
+            }
+        });
+    });
+

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/bdcTerraLink.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/bdcTerraLink.hbs
@@ -1,0 +1,34 @@
+<style>
+    #bdc-terra-body ul {
+        list-style-type: none;
+    }
+
+    #bdc-terra-body li {
+        margin: 10px 0;
+    }
+
+    #bdc-terra-body button,
+    #bdc-terra-body a {
+        width: 100%;
+        text-align: left;
+    }
+</style>
+<p class="sub-title">Please select your preferred programming language and platform.</p>
+<div style="margin: 30px auto 0 auto; width: max-content" id="bdc-terra-body">
+    <ul>
+        <li>
+            <a class="btn btn-lg btn-primary" href="https://tinyurl.com/BDC-PIC-SURE-API-Python-Terra"
+               target="_blank" tabindex="0">
+                Python - Jupyter Notebook
+                <i class="fa-solid fa-arrow-up-right-from-square"></i>
+            </a>
+        </li>
+        <li>
+            <a class="btn btn-lg btn-primary" href="https://tinyurl.com/BDC-PIC-SURE-API-R-Terra" target="_blank"
+               tabindex="0">
+                R - Jupyter Notebook
+                <i class="fa-solid fa-arrow-up-right-from-square"></i>
+            </a>
+        </li>
+    </ul>
+</div>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/bdcTerraLinkView.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/bdcTerraLinkView.js
@@ -1,0 +1,16 @@
+define(["jquery", "handlebars", "backbone", "text!api-interface/bdcTerraLink.hbs"],
+    function ($, HBS, BB, bdcTerraModalTemplate) {
+
+        var View = BB.View.extend({
+            initialize: function (opts) {
+                this.template = HBS.compile(bdcTerraModalTemplate);
+            },
+            events: {},
+            render: function () {
+                this.$el.html(this.template);
+                return this;
+            }
+        });
+
+        return View;
+    });

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/common/pic-sure-dialog-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/common/pic-sure-dialog-view.js
@@ -15,7 +15,7 @@ define([
                 button.classes && btnEl.classList.add(...button.classes.split(' '));
                 btnEl.tabIndex = 0;
                 return btnEl;
-            });;
+            });
             this.previousView = opts.previousView;
         },
         onClose: function() {

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/header/header.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/header/header.hbs
@@ -97,6 +97,7 @@
         {{/contains}}
         {{#contains privileges 'FENCE_PRIV_OPEN_ACCESS'}}
             <a class="header-btn header-navigation" data-href="/picsureui/openAccess#" href="#" id="open-access-btn" tabindex="-1" title="Open Access" aria-label="Open Access">Open Access</a>
+            <a id="api-btn" data-href="/picsureui/api" class="header-navigation header-btn authenticated-visible" href="#" tabindex="-1" title="API" aria-haspopup="true" aria-label="API">API</a>
             <button data-intro="#help-header-button" data-sequence="14" class="dropdown-toggle nav-dropdown header-btn authenticated-visible" aria-expanded="false" id="help-dropdown-toggle" tabindex="-1" title="Help" aria-label="Help dropwdown" aria-controls="help-menu-list">
                 Help <i class="fa fa-caret-down" aria-hidden="true"></i>
             </button>
@@ -107,7 +108,6 @@
                 {{#if documentationLink}}<li id="documentation-option" class="dropdown" aria-label="BioData Catalyst Documentation, clicking here will open a link  in a new tab"><a href="{{{documentationLink}}}">BioData Catalyst Documentation</a></li>{{/if}}
                 {{#if helpLink}}<li id="contact-us-option" class="dropdown" aria-label="Contact Us link, clicking here will open a link in a new tab"><a href="{{{helpLink}}}">Contact Us</a></li>{{/if}}
             </ul>
-            <a id="user-profile-btn" class="header-btn authenticated-visible" href="#" tabindex="-1" title="User Profile" aria-haspopup="true" aria-label="User Profile">User Profile</a>
             <a href="#" id="logout-btn" class="header-btn authenticated-visible" tabindex="-1" title="Log Out" aria-label="Log Out">Log Out</a>
         {{/contains}}
     </nav>

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/header.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/header.js
@@ -8,10 +8,7 @@ define([
 ],function (
 	keyboardNav,
 	dropdown,
-	menuNavControls,
-	modal,
-	userProfile,
-	userFunctions,
+	menuNavControls
 ) {
 
 	let headerTabs = undefined;
@@ -23,7 +20,7 @@ define([
 		console.debug("tabsFocus", e.target);
 		keyboardNav.setCurrentView("headerTabs");
 		dropdown.isOpen() ? e.target.querySelector('.header-btn.nav-dropdown').classList.add('selected') : headerTabs.querySelector('.header-btn.active').classList.add('selected');
-	}
+	};
 
 	/*
 		If the tabs loose focus and the loss of focus is from something out side the #header-tabs div then
@@ -41,13 +38,6 @@ define([
 			dropdown.closeDropdown(e);
 		}
 	}
-  
-	let openUserProfileModal = (e) => {
-		keyboardNav.setCurrentView(undefined);
-		userFunctions.meWithToken(this, (user) => {
-			modal.displayModal(new userProfile(user), 'User Profile', ()=>{e.target.focus();}, {isHandleTabs: true});
-		});
-	}
 
 	return {
 		/*
@@ -57,8 +47,6 @@ define([
 			*/
 		logoPath: undefined,
 		renderExt: function (view) {
-			//Override the core UI click #user-profile-btn event
-			view.delegateEvents(_.extend(view.events, { "click #user-profile-btn": openUserProfileModal }));
 			dropdown.init(view, [
 				{'click #help-dropdown-toggle': dropdown.toggleDropdown}, 
 				{'blur .nav-dropdown-menu': dropdown.dropdownBlur}

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/header.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/header.js
@@ -8,7 +8,7 @@ define([
 ],function (
 	keyboardNav,
 	dropdown,
-	menuNavControls
+	menuNavControls,
 ) {
 
 	let headerTabs = undefined;

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -1,11 +1,11 @@
 define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layoutTemplate.hbs", "picSure/settings", "filter/filterList",
         "openPicsure/outputPanel", "picSure/queryBuilder", "text!openPicsure/searchHelpTooltipOpen.hbs", "overrides/outputPanel",
         "search-interface/filter-list-view", "search-interface/search-view", "search-interface/tool-suite-view",
-        "search-interface/query-results-view", "openPicsure/studiesPanelView", "search-interface/filter-model",
+        "search-interface/query-results-view", "openPicsure/studiesPanelView", "api-interface/apiPanelView", "search-interface/filter-model",
         "search-interface/tag-filter-model"],
     function(BB, HBS, studyAccess, layoutTemplate, settings, filterList,
              outputPanel, queryBuilder, searchHelpTooltipTemplate, output,
-             FilterListView, SearchView, ToolSuiteView, queryResultsView, studiesPanelView, filterModel, tagFilterModel){
+             FilterListView, SearchView, ToolSuiteView, queryResultsView, studiesPanelView, ApiPanelView, filterModel, tagFilterModel) {
         const genomicFilterWarningText = 'Genomic filters will be removed from your query as they are not currently supported in Open Access. Are you sure you would like to proceed to Open Access? \n\nClick OK to proceed to open access or cancel to reutrn to authorized access.';
         let displayDataAccess = function() {
             $(".header-btn.active").removeClass('active');
@@ -61,6 +61,19 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
             });
             filterListView.render();
         };
+
+        let displayAPI = function() {
+            console.log('displayAPI');
+            $(".header-btn.active").removeClass('active');
+            $(".header-btn[data-href='/picsureui/api']").addClass('active');
+            $('#main-content').empty();
+            $('#main-content').append();
+
+            var apiPanelView = new ApiPanelView({});
+            $('#main-content').append(apiPanelView.$el);
+            apiPanelView.render();
+        };
+
         return {
             routes : {
                 /**
@@ -140,7 +153,8 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
                     filterListView.render();
 
                     toolSuiteView.render();
-                }
+                },
+                "picsureui/api" : displayAPI,
             },
             defaultAction: displayDataAccess
         };

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -67,7 +67,6 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
             $(".header-btn.active").removeClass('active');
             $(".header-btn[data-href='/picsureui/api']").addClass('active');
             $('#main-content').empty();
-            $('#main-content').append();
 
             var apiPanelView = new ApiPanelView({});
             $('#main-content').append(apiPanelView.$el);

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -63,7 +63,6 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
         };
 
         let displayAPI = function() {
-            console.log('displayAPI');
             $(".header-btn.active").removeClass('active');
             $(".header-btn[data-href='/picsureui/api']").addClass('active');
             $('#main-content').empty();


### PR DESCRIPTION
The old "User Profile" modal has been removed and substituted with a new API view that includes all the data from the previous modal, along with additional details related to the BDC API.
