### PR TITLE
Fix hyperlink icons

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanel.hbs
@@ -32,6 +32,12 @@
         min-width: 1200px;
     }
 
+    a > i {
+        pointer-events: none;
+    }
+
+
+
 </style>
 <div class="panel panel-outline" id="intro-section">
     <div class="panel-heading no-border center-panel">
@@ -77,14 +83,14 @@
             <a class="btn btn-primary btn-lg"
                href="https://github.com/hms-dbmi/Access-to-Data-using-PIC-SURE-API/tree/master/NHLBI_BioData_Catalyst"
                aria-label="Clicking here will take you to the given link in another tab." target="_blank">
+                Public GitHub Repository
                 <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                <span>Public GitHub Repository</span>
             </a>
             <a class="btn btn-primary btn-lg"
                href="https://accounts.sb.biodatacatalyst.nhlbi.nih.gov/auth/login"
                aria-label="Clicking here will take you to the given link in another tab." target="_blank">
-                <i class="fa-solid fa-arrow-up-right-from-square"></i>
                 BDC Powered by Seven Bridges
+                <i class="fa-solid fa-arrow-up-right-from-square"></i>
             </a>
             <button class="btn btn-primary btn-lg" id="bdc-powered-by-terra"
                     aria-label="Clicking this button will open a modal.">


### PR DESCRIPTION
Made it so icons can't be clicked on if they are inside of an `<a>` element. This ensures that the <a> event will fire and not the icon one. I moved the icons for buttons that had it aligned to the left of the text. Lastly, I removed the span around the github button. This fixed the blank href issue.