### PR TITLE
Update router getInvalidActiveFilters

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -24,10 +24,19 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
         let getInvalidActiveFilters = function() {
             const session = JSON.parse(sessionStorage.getItem("session"));
             return filterModel.get('activeFilters').filter(filter => {
-                const filterStudyId = '\\'+filter.get('searchResult').result.metadata.columnmeta_study_id+'\\'
-                return session.queryScopes && !session.queryScopes.includes(filterStudyId);
+                if (filter.get('type') === 'genomic') {
+                    let genomicValues = ['Gene_with_variant'];
+                    const isValidGenomic = session.queryScopes.filter(scope => {
+                        return genomicValues.includes(scope);
+                    });
+                    return session.queryScopes && !isValidGenomic;
+                } else {
+                    const filterStudyId = '\\'+filter.get('searchResult').result.metadata.columnmeta_study_id+'\\';
+                    return session.queryScopes && !session.queryScopes.includes(filterStudyId);
+                }
             });
         };
+
         let displayOpenAccess = function() {
             sessionStorage.setItem("isOpenAccess", true);
             Backbone.pubSub.trigger('destroySearchView');
@@ -111,7 +120,7 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
                         } else {
                             this.navigate('picsureui/openAccess#', {trigger:true, replace:false});
                             return;
-                        }  
+                        }
                     }
                     Backbone.pubSub.trigger('destroySearchView');
                     $(".header-btn.active").removeClass('active');

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -25,11 +25,7 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "text!common/layout
             const session = JSON.parse(sessionStorage.getItem("session"));
             return filterModel.get('activeFilters').filter(filter => {
                 if (filter.get('type') === 'genomic') {
-                    let genomicValues = ['Gene_with_variant'];
-                    const isValidGenomic = session.queryScopes.filter(scope => {
-                        return genomicValues.includes(scope);
-                    });
-                    return session.queryScopes && !isValidGenomic;
+                    return session.queryScopes && !session.queryScopes.includes('Gene_with_variant');
                 } else {
                     const filterStudyId = '\\'+filter.get('searchResult').result.metadata.columnmeta_study_id+'\\';
                     return session.queryScopes && !session.queryScopes.includes(filterStudyId);


### PR DESCRIPTION
Updating getInvalidActiveFilters we now check if they at least 'Gene_with_variant' in their query scope. We do not restrict genomic filtering based on studies so we cannot verify if they are permitted to access a specific gene like we can with selected variables.