### PR TITLE
Fix links across BDC

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanel.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanel.hbs
@@ -32,12 +32,6 @@
         min-width: 1200px;
     }
 
-    a > i {
-        pointer-events: none;
-    }
-
-
-
 </style>
 <div class="panel panel-outline" id="intro-section">
     <div class="panel-heading no-border center-panel">

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/footer.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/footer.hbs
@@ -1,3 +1,8 @@
+<style>
+    a * {
+       pointer-events: none;
+    }
+</style>
 <div class="row footer-row">
 <p class="center">
 


### PR DESCRIPTION
Any element nested with in an <a> element is no longer clickable. This ensure that if a <a> is clicked it's on click function fires.