### PR TITLE
Update redirectModal to be 508 compliant

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/studiesPanelView.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/studiesPanelView.js
@@ -49,7 +49,7 @@ define(["jquery","backbone", "handlebars", "text!openPicsure/studiesPanel.hbs", 
                 target = $('#studies-list').find('.' + SELECTED).find('.request-access')[0];
             }
 
-            redirectModal(target.getAttribute("data-href"), dialog, modal);
+            redirectModal(event, dialog, modal, target.getAttribute("data-href"));
         },
         exploreAccess: function(event) {
             window.history.pushState({}, "", "picsureui/queryBuilder");

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/footer.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/footer.js
@@ -1,6 +1,7 @@
-function redirectModal(href, dialog, modal) {
+function redirectModal(event, dialog, modal, url = undefined) {
     let closeModal = () => {
         $('.close')?.get(0).click();
+        $(event.target).focus();
     };
 
     const dialogOption = [
@@ -14,8 +15,8 @@ function redirectModal(href, dialog, modal) {
         {
             title: "Continue",
             "action": () => {
+                window.open((url === undefined ? event.target.href : url), '_blank');
                 closeModal();
-                window.open(href, '_blank');
             },
             classes: "btn btn-primary"
         }
@@ -73,7 +74,7 @@ define(["handlebars", "text!overrides/footer.hbs", "common/modal", "common/sessi
                 $(document).on('click', 'a[target="_blank"]', function (event) {
                     event.preventDefault();
 
-                    redirectModal(event.target.href, dialog, modal);
+                    redirectModal(event, dialog, modal);
                 });
             }
         };


### PR DESCRIPTION
In order to be 508 compliant we need to ensure we focus on the original event.target after the modal is closed.