### PR TITLE
Update redirect-modal.js

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/common/redirect-modal.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/common/redirect-modal.js
@@ -5,28 +5,55 @@ define([
         "common/pic-sure-dialog-view"
     ],
     function (BB, $, modal, dialog) {
+        function handleParentModal(e, sourceEvent) {
+            let parent = $(sourceEvent.target).parent();
+            while (parent.length && !parent.is('body') && !parent.is('.modal-content')) {
+                parent = parent.parent();
+            }
+
+            // if we traversed up the parents of the source and found the .modal-content class,
+            // then the source is a child of a modal window
+            if (parent.is('.modal-content')) {
+                $('#modal-window .modal-dialog').show();
+                $("body").append('<div class="modal-backdrop in"></div>');
+
+                $('#modalDialog').on('hidden.bs.modal', function (e) {
+                    e.preventDefault();
+
+                    $('#modal-window .modal-dialog').hide();
+                    $(".modal-backdrop").hide();
+                });
+            }
+        }
+
         return BB.View.extend({
             initialize: function (opts) {
                 this.data = opts || {};
             },
             render: function (sourceEvent, url = undefined) {
-                let closeModal = function () {
+                let closeModal = function (e) {
+                    e.preventDefault();
+
                     $('#modal-redirect .close')?.get(0).click();
+                    handleParentModal(e, sourceEvent);
+                    if (sourceEvent) {
+                        sourceEvent.target.focus();
+                    }
                 };
 
                 const dialogOption = [
                     {
                         title: "Cancel",
-                        "action": () => {
-                            closeModal();
+                        "action": (e) => {
+                            closeModal(e);
                         },
                         classes: "btn btn-default"
                     },
                     {
                         title: "Continue",
-                        "action": () => {
+                        "action": (e) => {
                             window.open((url === undefined ? sourceEvent.target.href : url), '_blank');
-                            closeModal();
+                            closeModal(e);
                         },
                         classes: "btn btn-primary"
                     }
@@ -57,25 +84,6 @@ define([
                     }
                     , {isHandleTabs: true, width: "450px", modalContainerId: modalContainerId}
                 );
-
-                $('#modal-redirect .close').click(function () {
-                    let parent = $(sourceEvent.target).parent();
-                    while (parent.length && !parent.is('body') && !parent.is('.modal-content')) {
-                        parent = parent.parent();
-                    }
-
-                    // If we traversed up to the body, then we clicked outside the modal
-                    if (parent.is('.modal-content')) {
-                        // Add a backdrop to the modal
-                        if ($('.modal-backdrop in').length === 0) {
-                            $('body').append('<div class="modal-backdrop in"></div>');
-                        } else {
-                            $('.modal-backdrop').show();
-                        }
-                    }
-
-                    $('#modal-window .modal-dialog').show();
-                });
             }
         });
     });


### PR DESCRIPTION
When the redirect modal was closed we appended a modal backdrop to the body if the source event parent was a modal. We needed to add an on event listener to ensure we also close the modal-backdrop on close.